### PR TITLE
skip truncate escape option to avoid html code from showing

### DIFF
--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -19,7 +19,7 @@
 					<%= link_to blog_path(blog) do %>
 					<div>
 						<h3><%= blog.title %></h3>
-						<%= truncate(blog.content.html_safe, length: 400) %>
+						<%= truncate(blog.content.html_safe, length: 400, escape: false) %>
 						<%= blog.published_at.strftime("%m/%d/%Y") if !blog.published_at.nil? %>
 					</div>
 					<% end %>


### PR DESCRIPTION
It seems like `truncate` is already marking content as HTML safe, escaping it by default at the same time.
Adding `escape: false` solves the issue.